### PR TITLE
種族を変更した歳、chackRace 関数内でデーモンルーラーが再度有効になるように

### DIFF
--- a/_core/lib/blp/view-chara.pl
+++ b/_core/lib/blp/view-chara.pl
@@ -117,7 +117,7 @@ if(!$::in{'backup'}){
         $pc{'fromPartner1SealShape'}    = $pr{'toPartner'.$pc{'partnerOrder'}.'SealShape'};
         $pc{'fromPartner1Emotion1'}     = $pr{'toPartner'.$pc{'partnerOrder'}.'Emotion1'};
         $pc{'fromPartner1Emotion2'}     = $pr{'toPartner'.$pc{'partnerOrder'}.'Emotion2'};
-        $pc{'p1_imageSrc'} = $pr{'imageURL'};
+        $pc{'p1_imageSrc'} = $pr{'imageURL'}."?$pr{'imageUpdate'}";
       }
       if($pr{'forbidden'}){
         $pc{'partner1Name'} = noiseText(6,14);
@@ -151,7 +151,7 @@ if(!$::in{'backup'}){
         $pc{'fromPartner2SealShape'}    = $pr{'toPartner'.$num.'SealShape'};
         $pc{'fromPartner2Emotion1'}     = $pr{'toPartner'.$num.'Emotion1'};
         $pc{'fromPartner2Emotion2'}     = $pr{'toPartner'.$num.'Emotion2'};
-        $pc{'p2_imageSrc'} = $pr{'imageURL'};
+        $pc{'p2_imageSrc'} = $pr{'imageURL'}."?$pr{'imageUpdate'}";;
       }
     }
   }

--- a/_core/lib/dx3/edit-chara.js
+++ b/_core/lib/dx3/edit-chara.js
@@ -83,6 +83,9 @@ function calcStt() {
     for(let i = base; i < base+grow; i++){
       exps['status'] += (i > 20) ? 30 : (i > 10) ? 20 : 10;
     }
+
+    // 能力値0の場合のエラー
+    form[`sttGrow${Stt}`].classList.toggle('error', syn1 && form.sttWorks.value && !(base + grow));
   }
   document.getElementById('exp-status').innerHTML = exps['status'];
   calcSubStt();

--- a/_core/lib/dx3/edit-chara.pl
+++ b/_core/lib/dx3/edit-chara.pl
@@ -372,6 +372,7 @@ print <<"HTML";
               </tr>
             </tbody>
           </table>
+          <div class="annotate" style="border-top-width:1px;border-top-style:dotted;">※コンストラクション作成のフリーポイント3点は「成長」欄に記入してください。</div>
         </div>
         <div class="box-union" id="sub-status">
           <dl class="box" id="max-hp">

--- a/_core/lib/sw2/edit-chara.js
+++ b/_core/lib/sw2/edit-chara.js
@@ -213,7 +213,7 @@ function checkRace(){
   raceAbilityMp        = 0;
   raceAbilityMagicPower= 0;
   
-  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid','Alc']) {
+  for (const name of ['Fig', 'Gra', 'Fen', 'Sho', 'Sor', 'Con', 'Pri', 'Fai', 'Mag', 'Dru', 'Dem', 'Sco', 'Ran', 'Sag', 'Enh', 'Bar', 'Rid','Alc']) {
     document.getElementById("class"+name).classList.remove('fail');
   }
   

--- a/_core/skin/_common/js/sheet.js
+++ b/_core/skin/_common/js/sheet.js
@@ -1,7 +1,12 @@
 // 開閉系 ----------------------------------------
-function popImage() {
+function popImage(id) {
+  if(typeof images !== 'undefined'){
+    id ||= 1;
+    document.getElementById('image-box-image').src = images[id];
+  }
   document.getElementById("image-box").style.bottom = 0;
   document.getElementById("image-box").style.opacity = 1;
+
 }
 function closeImage() {
   document.getElementById("image-box").style.opacity = 0;

--- a/_core/skin/blp/sheet-chara.html
+++ b/_core/skin/blp/sheet-chara.html
@@ -23,6 +23,11 @@ const paletteTool = '<TMPL_VAR paletteTool>';
 const generateType = 'BloodPathPC';
 const defaultImage = '<TMPL_VAR coreDir>/skin/blp/img/default.png';
 
+const images = {
+  '1' : "<TMPL_VAR imageSrc>",
+  'p1' : "<TMPL_VAR p1_imageSrc>",
+  'p2' : "<TMPL_VAR p2_imageSrc>",
+};
 <TMPL_IF error>
 window.onload = function() {
   editOn();
@@ -264,7 +269,7 @@ window.onload = function() {
         <div class="partner" id="partner1">
           <TMPL_IF p1_image> 
           <div class="image" style="background-image: url(<TMPL_VAR p1_imageSrc>);background-size:<TMPL_VAR p1_imageFit>;background-position:<TMPL_VAR p1_imagePositionX>% <TMPL_VAR p1_imagePositionY>%;">
-          <div onclick=""><p class="words" style="<TMPL_VAR p1_wordsX><TMPL_VAR p1_wordsY>"><TMPL_VAR p1_words></p></div>
+          <div onclick="popImage('p1')"><p class="words" style="<TMPL_VAR p1_wordsX><TMPL_VAR p1_wordsY>"><TMPL_VAR p1_words></p></div>
           <p class="image-copyright"><TMPL_VAR p1_imageCopyright></p>
           </div>
           <TMPL_ELSE>
@@ -294,7 +299,7 @@ window.onload = function() {
         <div class="partner" id="partner2">
           <TMPL_IF p2_image> 
           <div class="image" style="background-image: url(<TMPL_VAR p2_imageSrc>);background-size:<TMPL_VAR p2_imageFit>;background-position:<TMPL_VAR p2_imagePositionX>% <TMPL_VAR p2_imagePositionY>%;">
-          <div onclick=""><p class="words" style="<TMPL_VAR p2_wordsX><TMPL_VAR p2_wordsY>"><TMPL_VAR p2_words></p></div>
+          <div onclick="popImage('p2')"><p class="words" style="<TMPL_VAR p2_wordsX><TMPL_VAR p2_wordsY>"><TMPL_VAR p2_words></p></div>
           <p class="image-copyright"><TMPL_VAR p2_imageCopyright></p>
           </div>
           <TMPL_ELSE>


### PR DESCRIPTION
> [2.5キャラシで種族：マナフレア選択後に別の種族へ変えた際にデーモンルーラー技能のみ取得不可の×マークが消えなくなるようです（他の魔法技能はちゃんと消える） ](https://discord.com/channels/463088353794064384/465834682613760000/915458455186333738)
なる話に対する対応