### PR TITLE
エルフやルーンフォークを能力作成ダイスからキャラメイクすると初期値が希少種になる件への対応

### DIFF
--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -61,7 +61,7 @@ elsif($mode eq 'blanksheet'){
   if($::in{'stt'}){
     ($pc{'sttBaseTec'}, $pc{'sttBasePhy'}, $pc{'sttBaseSpi'}, $pc{'sttBaseA'}, $pc{'sttBaseB'}, $pc{'sttBaseC'}, $pc{'sttBaseD'}, $pc{'sttBaseE'}, $pc{'sttBaseF'}) = split(/_/, $::in{'stt'});
     $pc{'race'} = Encode::decode('utf8', $::in{'race'});
-    if($data::races{$pc{'race'}}{'variant'}){
+    if($data::races{$pc{'race'}}{'variant'} && ! ($data::races{$pc{'race'}}{'ability'})){
       $pc{'race'} .= "（$data::races{$pc{'race'}}{'variantSort'}[0]）";
     }
     if($::in{'making_num'}){

--- a/_core/lib/sw2/edit-chara.pl
+++ b/_core/lib/sw2/edit-chara.pl
@@ -61,7 +61,10 @@ elsif($mode eq 'blanksheet'){
   if($::in{'stt'}){
     ($pc{'sttBaseTec'}, $pc{'sttBasePhy'}, $pc{'sttBaseSpi'}, $pc{'sttBaseA'}, $pc{'sttBaseB'}, $pc{'sttBaseC'}, $pc{'sttBaseD'}, $pc{'sttBaseE'}, $pc{'sttBaseF'}) = split(/_/, $::in{'stt'});
     $pc{'race'} = Encode::decode('utf8', $::in{'race'});
-    if($data::races{$pc{'race'}}{'variant'} && ! ($data::races{$pc{'race'}}{'ability'})){
+    if($data::races{$pc{'race'}}{'variant'} &&
+       # 通常種・希少種がいる場合は race 直下に ability がある
+       # そうでない場合（ナイトメアなど）は variant の各データ直下にしか ability はない
+       ! ($data::races{$pc{'race'}}{'ability'})){
       $pc{'race'} .= "（$data::races{$pc{'race'}}{'variantSort'}[0]）";
     }
     if($::in{'making_num'}){


### PR DESCRIPTION
スノウエルフや戦闘用ルーンフォークよりも通常のエルフやルーンフォークの方が選ばれる頻度は高いだろうという想定。

[`@race_list`](https://github.com/yutorize/ytsheet2/blob/92d0c561b70513c020f857a0e6685486eb94e1fb/_core/lib/sw2/data-races.pl#L630)の生成ロジックを参考に `variant` が種族内にある場合に通常種がいるか否かを判定するロジックを追加した。